### PR TITLE
Add secret for pkg

### DIFF
--- a/libs/egts/egts_pkg.go
+++ b/libs/egts/egts_pkg.go
@@ -43,8 +43,6 @@ type Options struct {
 	secretKey SecretKey
 }
 
-//type Option func(key *SecretKey)
-
 // Decode разбирает набор байт в структуру пакета
 func (p *Package) Decode(content []byte, opt ...func(*Options)) (uint8, error) {
 	options := &Options{}

--- a/libs/egts/egts_pkg.go
+++ b/libs/egts/egts_pkg.go
@@ -51,6 +51,7 @@ func (p *Package) Decode(content []byte, opt ...func(*Options)) (uint8, error) {
 	}
 
 	secretKey := options.secretKey
+
 	var (
 		err   error
 		flags byte


### PR DESCRIPTION
Changes:
- Added optional parameter to egts_package - secret. This option is used to decrypt/encrypt the egts_packet.
Encryption/decryption will work if the encryption type is specified in the EncryptionAlg parameter.
- Changed the "time" field of the ServiceDataRecord structure from the uint16 type to the time type.
- Added navigation time conversion for the ServiceDataRecord field to the format required by the standard: number of seconds since 00:00:00 01/01/2010 UTC